### PR TITLE
Reset orientation after scan

### DIFF
--- a/src/BarcodeScannerController.swift
+++ b/src/BarcodeScannerController.swift
@@ -408,8 +408,10 @@ class BarcodeScannerController : UIViewController, AVCaptureMetadataOutputObject
         qrCodeFrameView = nil
         messageLabel = nil
         captureSession = nil
+				pluginOrientation = ""
         
         if #available(iOS 16.0, *) {
+						setNeedsUpdateOfSupportedInterfaceOrientations()
             let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
             windowScene?.requestGeometryUpdate(.iOS(interfaceOrientations: originalOrientationMask!))
         } else {

--- a/src/BarcodeScannerController.swift
+++ b/src/BarcodeScannerController.swift
@@ -408,10 +408,10 @@ class BarcodeScannerController : UIViewController, AVCaptureMetadataOutputObject
         qrCodeFrameView = nil
         messageLabel = nil
         captureSession = nil
-				pluginOrientation = ""
+        pluginOrientation = ""
         
         if #available(iOS 16.0, *) {
-						setNeedsUpdateOfSupportedInterfaceOrientations()
+            setNeedsUpdateOfSupportedInterfaceOrientations()
             let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
             windowScene?.requestGeometryUpdate(.iOS(interfaceOrientations: originalOrientationMask!))
         } else {


### PR DESCRIPTION
Fix issue where after exiting the scanner, the app will stay in the rotation the scanner was configured for. e.g. if the scanner is configured for landscape, and is opened in portrait, the app will be stay in landscape after closing the scanner.